### PR TITLE
Change days logic

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 Jeff Brown
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/TeamsCloudCommunicationApi/TeamsCloudCommunicationApi.psd1
+++ b/TeamsCloudCommunicationApi/TeamsCloudCommunicationApi.psd1
@@ -12,7 +12,7 @@
 RootModule = 'TeamsCloudCommunicationApi.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.2.2'
+ModuleVersion = '0.3.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')
@@ -102,7 +102,7 @@ PrivateData = @{
         Tags = @('microsoft-teams', 'graph-api')
 
         # A URL to the license for this module.
-        # LicenseUri = ''
+        LicenseUri = 'https://github.com/JeffBrownTech/TeamsCloudCommunicationApi/blob/master/LICENSE'
 
         # A URL to the main website for this project.
         ProjectUri = 'https://github.com/JeffBrownTech/TeamsCloudCommunicationApi'

--- a/TeamsCloudCommunicationApi/TeamsCloudCommunicationApi.psm1
+++ b/TeamsCloudCommunicationApi/TeamsCloudCommunicationApi.psm1
@@ -157,11 +157,10 @@ function Get-TeamsPstnCalls {
         $requestUri = "https://graph.microsoft.com/beta/communications/callRecords/getPstnCalls(fromDateTime=$StartDate,toDateTime=$EndDate)"
     }
     elseif ($PSCmdlet.ParameterSetName -eq "NumberDays") {
-        $toDateTime = [datetime]::Today.AddDays(1)
+        $today = [datetime]::Today
+        $toDateTime = $today.AddDays(1)
         $toDateTimeString = Get-Date -Date $toDateTime -Format yyyy-MM-dd
-
-        $adjustedDays = $Days - 1
-        $fromDateTime = $toDateTime.AddDays(-$adjustedDays)
+        $fromDateTime = $today.AddDays(-($Days - 1))
         $fromDateTimeString = Get-Date -Date $fromDateTime -Format yyyy-MM-dd
 
         $requestUri = "https://graph.microsoft.com/beta/communications/callRecords/getPstnCalls(fromDateTime=$fromDateTimeString,toDateTime=$toDateTimeString)"
@@ -270,11 +269,10 @@ function Get-TeamsDirectRoutingCalls {
         $requestUri = "https://graph.microsoft.com/beta/communications/callRecords/getDirectRoutingCalls(fromDateTime=$StartDate,toDateTime=$EndDate)"
     }
     elseif ($PSCmdlet.ParameterSetName -eq "NumberDays") {
-        $toDateTime = [datetime]::Today.AddDays(1)
+        $today = [datetime]::Today
+        $toDateTime = $today.AddDays(1)
         $toDateTimeString = Get-Date -Date $toDateTime -Format yyyy-MM-dd
-
-        $adjustedDays = $Days - 1
-        $fromDateTime = $toDateTime.AddDays(-$adjustedDays)
+        $fromDateTime = $today.AddDays(-($Days - 1))
         $fromDateTimeString = Get-Date -Date $fromDateTime -Format yyyy-MM-dd
 
         $requestUri = "https://graph.microsoft.com/beta/communications/callRecords/getDirectRoutingCalls(fromDateTime=$fromDateTimeString,toDateTime=$toDateTimeString)"


### PR DESCRIPTION
Changed -Days parameter logic. When inputting 1, it will get the current date's records (based on UTC time). When specifying 2 days, it will get the current day and yesterday. Since the Graph API does not allow specifying times when gathering PSTN records, this will get the closest approximation of records to match what you can retrieve in the usage reports in the Teams admin center.